### PR TITLE
replaced minetest.setting_* with new, correct, system

### DIFF
--- a/mods/aftermath/itemdrop.lua
+++ b/mods/aftermath/itemdrop.lua
@@ -1,6 +1,6 @@
 minetest.register_globalstep(function(dtime)
 	for _,player in ipairs(minetest.get_connected_players()) do
-		if player:get_hp() > 0 or not minetest.setting_getbool("enable_damage") then
+		if player:get_hp() > 0 or not minetest.settings:get_bool("enable_damage") then
 			local pos = player:getpos()
 			pos.y = pos.y+0.5
 			local inv = player:get_inventory()
@@ -28,7 +28,7 @@ end)
 
 function minetest.handle_node_drops(pos, drops, digger)
 	local inv
-	if minetest.setting_getbool("creative_mode") and digger and digger:is_player() then
+	if minetest.settings:get_bool("creative_mode") and digger and digger:is_player() then
 		inv = digger:get_inventory()
 	end
 	for _,item in ipairs(drops) do
@@ -56,8 +56,8 @@ function minetest.handle_node_drops(pos, drops, digger)
 					obj:setvelocity({x=1/x, y=obj:getvelocity().y, z=1/z})
 					
 					-- FIXME this doesnt work for deactiveted objects
-					if minetest.setting_get("remove_items") and tonumber(minetest.setting_get("remove_items")) then
-						minetest.after(tonumber(minetest.setting_get("remove_items")), function(obj)
+					if minetest.settings:get("remove_items") and tonumber(minetest.settings:get("remove_items")) then
+						minetest.after(tonumber(minetest.settings:get("remove_items")), function(obj)
 							obj:remove()
 						end, obj)
 					end
@@ -67,6 +67,6 @@ function minetest.handle_node_drops(pos, drops, digger)
 	end
 end
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "item_drop loaded")
 end

--- a/mods/aftermath/killme.lua
+++ b/mods/aftermath/killme.lua
@@ -3,7 +3,7 @@ minetest.register_chatcommand("killme", {
 	func = function(name)
 		local player = minetest.get_player_by_name(name)
 		if player then
-			if minetest.setting_getbool("enable_damage") then
+			if minetest.settings:get_bool("enable_damage") then
 				player:set_hp(0)
 				return true
 			else

--- a/mods/aftermath/largehotbar.lua
+++ b/mods/aftermath/largehotbar.lua
@@ -2,7 +2,7 @@
 -- Copyright (c) 2015 Calinou
 -- CC0 1.0 Universal
 
-custom_hotbar_size = tonumber(minetest.setting_get("large_hotbar.size"))
+custom_hotbar_size = tonumber(minetest.settings:get("large_hotbar.size"))
 
 minetest.register_on_joinplayer(function(player)
   player:hud_set_hotbar_itemcount(custom_hotbar_size or 16)


### PR DESCRIPTION
Replaced minetest.setting_* with minetest.settings: to reduce warnings in the console. I only started with the main mod because the rest should be updated from their developers if possible.